### PR TITLE
add circuit breaker with rollback to ecs service

### DIFF
--- a/ecs_service.tf
+++ b/ecs_service.tf
@@ -28,7 +28,8 @@ resource "aws_ecs_service" "this" {
     ]
   }
 
-  deployment_controller {
-    type = "ECS"
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
   }
 }


### PR DESCRIPTION
- Remove `deployment_controller` configuration block as `ECS` type value is default
- Add circuit breaker with rollback for failed/bad deployment handling within service controller