### PR TITLE
add redirect codes to lb target group health check

### DIFF
--- a/alb_target_group.tf
+++ b/alb_target_group.tf
@@ -20,7 +20,7 @@ resource "aws_lb_target_group" "this" {
     timeout             = 3
     healthy_threshold   = 2
     unhealthy_threshold = 3
-    matcher             = "200"
+    matcher             = "200,301,308"
   }
 
   stickiness {

--- a/alb_target_group.tf
+++ b/alb_target_group.tf
@@ -20,7 +20,7 @@ resource "aws_lb_target_group" "this" {
     timeout             = 3
     healthy_threshold   = 2
     unhealthy_threshold = 3
-    matcher             = "200,301,308"
+    matcher             = "200,301,307,308"
   }
 
   stickiness {


### PR DESCRIPTION
- Add commonly used redirect codes to health check

There are many circumstances that a healthcheck on `/` (root) would need redirect to be detected as a healthy state.