### PR TITLE
Revert bump to 0.61.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can do this by commenting out the entire module, running a terraform apply, 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_database"></a> [database](#module\_database) | ./rds_cluster | n/a |
-| <a name="module_service_container_definition"></a> [service\_container\_definition](#module\_service\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.61.0 |
+| <a name="module_service_container_definition"></a> [service\_container\_definition](#module\_service\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.60.0 |
 
 ## Resources
 

--- a/ecs_task_definitions.tf
+++ b/ecs_task_definitions.tf
@@ -25,7 +25,7 @@ module "service_container_definition" {
   count = var.container_definitions != null ? 0 : 1
 
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.61.0"
+  version = "0.60.0"
 
   container_name   = var.service_name
   container_image  = var.container_image


### PR DESCRIPTION
Currently an unresolved issue on 0.61.0 of the cloudposse/ecs-container-definition/aws repo

https://github.com/cloudposse/terraform-aws-ecs-container-definition/pull/171

This makes the `terraform plan` command fail with this error
```
│ Error: Invalid type specification
│
│   on .terraform/modules/backend.service_container_definition/variables.tf line 107, in variable "container_definition":
│  102:     portMappings = optional(list(object({
│  103:       name          = optional(string)
│  104:       containerPort = number
│  105:       hostPort      = optional(number)
│  106:       protocol      = optional(string)
│  107:       name          = optional(string)
│  108:       appProtocol   = optional(string)
│  109:     })))
│
│ Object constructor map keys must be unique.
```