### PR TITLE
Add array index to fix bug in fallback value

### DIFF
--- a/ecs_task_definitions.tf
+++ b/ecs_task_definitions.tf
@@ -1,7 +1,7 @@
 
 resource "aws_ecs_task_definition" "service" {
   family                   = var.service_name
-  container_definitions    = var.container_definitions != null ? var.container_definitions : "[${module.service_container_definition.json_map_encoded}]"
+  container_definitions    = var.container_definitions != null ? var.container_definitions : "[${module.service_container_definition[0].json_map_encoded}]"
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn            = aws_iam_role.ecs_task_role.arn
   network_mode             = "awsvpc"


### PR DESCRIPTION
[There was a bug occurring on line 4 causing this issue](https://github.com/hashicorp/terraform/issues/21676)

- Add index `[0]` to property reference because of `count` value on `module.service_container_definition` instantiation`

Thank you @zacharyweidenbach 