### PR TITLE
move outputs to outputs.tf

### DIFF
--- a/ecs_task_definitions.tf
+++ b/ecs_task_definitions.tf
@@ -49,7 +49,3 @@ module "service_container_definition" {
     }
   }
 }
-
-output "log_group_name" {
-  value = aws_cloudwatch_log_group.service.name
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "log_group_name" {
+  value = aws_cloudwatch_log_group.service.name
+}

--- a/rds_cluster/main.tf
+++ b/rds_cluster/main.tf
@@ -56,15 +56,15 @@ resource "aws_secretsmanager_secret_version" "connection_string" {
 
 #tfsec:ignore:aws-rds-enable-performance-insights-encryption
 resource "aws_rds_cluster_instance" "this" {
-  count                           = var.instance_count
-  engine                          = "aurora-postgresql"
-  engine_version                  = "14.6"
-  identifier_prefix               = "${var.name}-${count.index + 1}"
-  performance_insights_enabled    = true
-  cluster_identifier              = aws_rds_cluster.this.id
-  instance_class                  = var.instance_class
-  db_subnet_group_name            = aws_db_subnet_group.this.name
-  tags                            = var.tags
+  count                        = var.instance_count
+  engine                       = "aurora-postgresql"
+  engine_version               = "14.6"
+  identifier_prefix            = "${var.name}-${count.index + 1}"
+  performance_insights_enabled = true
+  cluster_identifier           = aws_rds_cluster.this.id
+  instance_class               = var.instance_class
+  db_subnet_group_name         = aws_db_subnet_group.this.name
+  tags                         = var.tags
 }
 
 resource "aws_db_subnet_group" "this" {
@@ -97,20 +97,4 @@ resource "aws_security_group" "this" {
 
 data "aws_vpc" "database_vpc" {
   id = var.vpc_id
-}
-
-output "db_cluster_id" {
-  value = aws_rds_cluster.this.cluster_identifier
-}
-
-output "security_group_id" {
-  value = aws_security_group.this.id
-}
-
-output "root_password_secret_id" {
-  value = aws_secretsmanager_secret.root_password.id
-}
-
-output "connection_string_arn" {
-  value = aws_secretsmanager_secret.connection_string.arn
 }

--- a/rds_cluster/outputs.tf
+++ b/rds_cluster/outputs.tf
@@ -1,0 +1,16 @@
+
+output "db_cluster_id" {
+  value = aws_rds_cluster.this.cluster_identifier
+}
+
+output "security_group_id" {
+  value = aws_security_group.this.id
+}
+
+output "root_password_secret_id" {
+  value = aws_secretsmanager_secret.root_password.id
+}
+
+output "connection_string_arn" {
+  value = aws_secretsmanager_secret.connection_string.arn
+}


### PR DESCRIPTION
Moving outputs to `outputs.tf` to better follow best practices