### PR TITLE
Add terraform-aws-ecs-service to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terraform-aws-ecs-service
+spec:
+  type: library
+  lifecycle: production
+  owner: platform


### PR DESCRIPTION

## TL;DR

This pull request registers terraform-aws-ecs-service, as a component in our Backstage Software Catalog. 
It lists our team, platform, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → https://synapsestudios.spotifyportal.com/catalog

## What is Portal?

[Portal](https://backstage.spotify.com/products/portal) is an internal developer portal based on [Backstage](https://backstage.io/). It's goal is making developers' lives easier. Portal unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.
