### PR TITLE
Set CA cert authority value for aurora cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can do this by commenting out the entire module, running a terraform apply, 
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Hostname to use for listener rule | `string` | n/a | yes |
 | <a name="input_listener_arn"></a> [listener\_arn](#input\_listener\_arn) | ALB listener ARN to add listener rule to | `string` | n/a | yes |
 | <a name="input_load_balancer_container_name"></a> [load\_balancer\_container\_name](#input\_load\_balancer\_container\_name) | Container name to use for load balancer target group forwarder | `string` | `null` | no |
+| <a name="input_rds_cluster_engine_version"></a> [rds\_cluster\_engine\_version](#input\_rds\_cluster\_engine\_version) | Database engine version | `string` | `"14.6"` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service directory in the application git repo | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnet names the service will reside on. | `list(string)` | n/a | yes |
 | <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | Task CPU | `number` | `1024` | no |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can do this by commenting out the entire module, running a terraform apply, 
 | <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | Security Group ID for the ALB | `string` | n/a | yes |
 | <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Whether or not to assign a public IP to the task | `bool` | `false` | no |
 | <a name="input_azs"></a> [azs](#input\_azs) | Availability zones | `list(string)` | n/a | yes |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Identifier of the CA certificate for the DB instance | `string` | `null` | no |
 | <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | ECS cluster to deploy into | `string` | n/a | yes |
 | <a name="input_command"></a> [command](#input\_command) | Container startup command (Use null if container\_definitions is set) | `list(string)` | n/a | yes |
 | <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | A list of valid container definitions provided as a single valid JSON document. By default, this module will generate a container definition for you. If you need to provide your own or have multiple, you can do so here. | `string` | `null` | no |

--- a/db.tf
+++ b/db.tf
@@ -9,4 +9,5 @@ module "database" {
   vpc_id             = var.vpc_id
   database_name      = var.db_name
   ca_cert_identifier = var.ca_cert_identifier
+  engine_version     = var.rds_cluster_engine_version
 }

--- a/db.tf
+++ b/db.tf
@@ -8,4 +8,5 @@ module "database" {
   name               = var.service_name
   vpc_id             = var.vpc_id
   database_name      = var.db_name
+  ca_cert_identifier = var.ca_cert_identifier
 }

--- a/rds_cluster/main.tf
+++ b/rds_cluster/main.tf
@@ -21,6 +21,7 @@ resource "aws_rds_cluster" "this" {
   tags                            = var.tags
   db_cluster_parameter_group_name = "default.aurora-postgresql14"
   deletion_protection             = true
+  ca_certificate_identifier       = var.ca_cert_identifier
 }
 
 resource "random_password" "password" {
@@ -65,6 +66,7 @@ resource "aws_rds_cluster_instance" "this" {
   instance_class               = var.instance_class
   db_subnet_group_name         = aws_db_subnet_group.this.name
   tags                         = var.tags
+  ca_cert_identifier           = var.ca_cert_identifier
 }
 
 resource "aws_db_subnet_group" "this" {

--- a/rds_cluster/main.tf
+++ b/rds_cluster/main.tf
@@ -6,7 +6,7 @@ resource "random_id" "final_snapshot_suffix" {
 resource "aws_rds_cluster" "this" {
   cluster_identifier_prefix       = var.name
   engine                          = "aurora-postgresql"
-  engine_version                  = "14.6"
+  engine_version                  = var.engine_version
   database_name                   = var.database_name
   skip_final_snapshot             = false
   final_snapshot_identifier       = "${var.name}-final-${random_id.final_snapshot_suffix.hex}"

--- a/rds_cluster/main.tf
+++ b/rds_cluster/main.tf
@@ -58,7 +58,7 @@ resource "aws_secretsmanager_secret_version" "connection_string" {
 resource "aws_rds_cluster_instance" "this" {
   count                        = var.instance_count
   engine                       = "aurora-postgresql"
-  engine_version               = "14.6"
+  engine_version               = var.engine_version
   identifier_prefix            = "${var.name}-${count.index + 1}"
   performance_insights_enabled = true
   cluster_identifier           = aws_rds_cluster.this.id

--- a/rds_cluster/main.tf
+++ b/rds_cluster/main.tf
@@ -21,7 +21,6 @@ resource "aws_rds_cluster" "this" {
   tags                            = var.tags
   db_cluster_parameter_group_name = "default.aurora-postgresql14"
   deletion_protection             = true
-  ca_certificate_identifier       = var.availability_zones.length && var.ca_cert_identifier ? var.ca_cert_identifier : null
 }
 
 resource "random_password" "password" {

--- a/rds_cluster/main.tf
+++ b/rds_cluster/main.tf
@@ -21,7 +21,7 @@ resource "aws_rds_cluster" "this" {
   tags                            = var.tags
   db_cluster_parameter_group_name = "default.aurora-postgresql14"
   deletion_protection             = true
-  ca_certificate_identifier       = var.ca_cert_identifier
+  ca_certificate_identifier       = var.availability_zones.length && var.ca_cert_identifier ? var.ca_cert_identifier : null
 }
 
 resource "random_password" "password" {

--- a/rds_cluster/variables.tf
+++ b/rds_cluster/variables.tf
@@ -50,3 +50,9 @@ variable "ca_cert_identifier" {
   description = "Identifier of the CA certificate for the DB instance"
   default     = null
 }
+
+variable "engine_version" {
+  type        = string
+  description = "Database engine version"
+  default     = "14.6"
+}

--- a/rds_cluster/variables.tf
+++ b/rds_cluster/variables.tf
@@ -44,3 +44,9 @@ variable "instance_class" {
   type        = string
   description = "Instance class"
 }
+
+variable "ca_cert_identifier" {
+  type        = string
+  description = "Identifier of the CA certificate for the DB instance"
+  default     = "rds-ca-rsa2048-g1"
+}

--- a/rds_cluster/variables.tf
+++ b/rds_cluster/variables.tf
@@ -48,5 +48,5 @@ variable "instance_class" {
 variable "ca_cert_identifier" {
   type        = string
   description = "Identifier of the CA certificate for the DB instance"
-  default     = "rds-ca-rsa2048-g1"
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -146,3 +146,9 @@ variable "ca_cert_identifier" {
   description = "Identifier of the CA certificate for the DB instance"
   default     = null
 }
+
+variable "rds_cluster_engine_version" {
+  type        = string
+  description = "Database engine version"
+  default     = "14.6"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,9 @@ variable "assign_public_ip" {
   description = "Whether or not to assign a public IP to the task"
   default     = false
 }
+
+variable "ca_cert_identifier" {
+  type        = string
+  description = "Identifier of the CA certificate for the DB instance"
+  default     = null
+}


### PR DESCRIPTION
Not sure what the best practice is here. I've set it to use the current default CA which is valid until 2061, but maybe there's a better way to make this optional or a better way to configure it for "latest". I set up the inputs so that the cluster and the instances get the same CA because I couldn't imagine a scenario where we want them to be different.

The CA Cert Authority variable doesn't seem important anymore, but I have a project that needs to be able to update its Aurora Postgres version, so I'm back to finishing this PR. I'm not sure why the tfscan is flagging so much stuff that's unrelated to my changes. Does that need to be fixed or can it be ignored?